### PR TITLE
fix: NullPointerException

### DIFF
--- a/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
+++ b/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
@@ -19,7 +19,6 @@ package me.saiintbrisson.bungee.command.command;
 import com.google.common.collect.Lists;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.val;
 import me.saiintbrisson.bungee.command.BungeeFrame;
 import me.saiintbrisson.bungee.command.executor.BungeeCommandExecutor;
 import me.saiintbrisson.bungee.command.target.BungeeTargetValidator;

--- a/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
+++ b/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
@@ -212,9 +212,8 @@ public class BungeeCommand extends Command implements CommandHolder<CommandSende
 
     @Override
     public List<String> getAliasesList() {
-        val aliases = this.getAliases();
-        if(Objects.isNull(aliases)) return Lists.newArrayList();
-        return Arrays.asList(aliases);
+        String[] aliases = this.getAliases();
+        return aliases == null ? Collections.emptyList() : Arrays.asList(aliases);
     }
 
     @Override

--- a/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
+++ b/bungee/src/main/java/me/saiintbrisson/bungee/command/command/BungeeCommand.java
@@ -19,6 +19,7 @@ package me.saiintbrisson.bungee.command.command;
 import com.google.common.collect.Lists;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.val;
 import me.saiintbrisson.bungee.command.BungeeFrame;
 import me.saiintbrisson.bungee.command.executor.BungeeCommandExecutor;
 import me.saiintbrisson.bungee.command.target.BungeeTargetValidator;
@@ -211,7 +212,9 @@ public class BungeeCommand extends Command implements CommandHolder<CommandSende
 
     @Override
     public List<String> getAliasesList() {
-        return Arrays.asList(getAliases());
+        val aliases = this.getAliases();
+        if(Objects.isNull(aliases)) return Lists.newArrayList();
+        return Arrays.asList(aliases);
     }
 
     @Override


### PR DESCRIPTION
Fixes an error appearing in the "bungee" structure. I just added a check for 'Objects.isNull()', making it work smoothly.

`02:54:14 [SEVERE] java.lang.NullPointerException
02:54:14 [SEVERE]     at java.base/java.util.Objects.requireNonNull(Objects.java:209)
02:54:14 [SEVERE]     at java.base/java.util.Arrays$ArrayList.<init>(Arrays.java:4137)
02:54:14 [SEVERE]     at java.base/java.util.Arrays.asList(Arrays.java:4122)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.command.BungeeCommand.getAliasesList(BungeeCommand.java:214)
02:54:14 [SEVERE]     at me.saiintbrisson.minecraft.command.command.CommandHolder.equals(CommandHolder.java:63)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.command.BungeeCommand.getChildCommand(BungeeCommand.java:186)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.command.BungeeCommand.createRecursive(BungeeCommand.java:203)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.BungeeFrame.getCommand(BungeeFrame.java:94)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.BungeeFrame.registerCommand(BungeeFrame.java:117)
02:54:14 [SEVERE]     at me.saiintbrisson.bungee.command.BungeeFrame.registerCommands(BungeeFrame.java:103)`

